### PR TITLE
Makefile updates

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -6,7 +6,7 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://download.qt.io/official_releases/qt/5.9/5.9.9/submodules/
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,7 +1,7 @@
 PACKAGE=qt
-$(package)_version=5.5.0
-$(package)_download_path=http://download.qt.io/archive/qt/5.5/$($(package)_version)/submodules
-$(package)_suffix=opensource-src-$($(package)_version).tar.gz
+$(package)_version=5.9.9
+$(package)_download_path=https://download.qt.io/official_releases/qt/5.9.9/$($(package)_version)/submodules
+$(package)_suffix=opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=7e82b1318f88e56a2a9376e069aa608d4fd96b48cb0e1b880ae658b0a1af0561
 $(package)_dependencies=openssl


### PR DESCRIPTION
Updated Makefiles to build Depends folder. URL ERROR 404 Issue. https://bitcoincore is no longer valid. Changed to 

Makefile
FALLBACK_DOWNLOAD_PATH ?= https://download.qt.io/official_releases/qt/5.9/5.9.9/submodules/

qt.mk
$(package)_version=5.9.9
$(package)_download_path=https://download.qt.io/official_releases/qt/5.9.9/$($(package)_version)/submodules
$(package)_suffix=opensource-src-$($(package)_version).tar.xz